### PR TITLE
Feature/Update-Record/Operations-Quantity-Error-Validation

### DIFF
--- a/KiczanProductionInfoSystem/DataValidation.cs
+++ b/KiczanProductionInfoSystem/DataValidation.cs
@@ -154,6 +154,19 @@ namespace KiczanProductionInfoSystem
             return message;
         }
 
+        // Validate Operations selection input.
+        internal string validateOperations(string input)
+        {
+            string message = "";
+
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                message = "Record not Complete!\nPlease select at least one Operation.";
+            }
+
+            return message;
+        }
+
         // Validate date received input.
         internal string validateDateReceived(string input)
         {

--- a/KiczanProductionInfoSystem/UpdateRecord.cs
+++ b/KiczanProductionInfoSystem/UpdateRecord.cs
@@ -170,11 +170,32 @@ namespace KiczanProductionInfoSystem
                 isValid = false;
             }
 
-            //TO DO: Quantity validation
+            //Quantity validation
+            string quantityError = newDV.validateQuantity(quantity);
+            if (!string.IsNullOrEmpty(quantityError))
+            {
+                labelQuantityError.Text = quantityError;
+                errorProvider1.SetError(textBoxQuantity, quantityError);
+                isValid = false;
+            }
 
+            //Operations validation
+            List<string> checkedItems = new List<string>();
 
-            //TO DO: Operations validation
+            foreach (var item in checkedListBox1.CheckedItems)
+            {
+                checkedItems.Add(item.ToString());
+            }
 
+            checkedOperations = string.Join(", ", checkedItems);
+
+            string operationsError = newDV.validateOperations(checkedOperations);
+            if (!string.IsNullOrEmpty(operationsError))
+            {
+                labelOperationsError.Text = operationsError;
+                errorProvider2.SetError(checkedListBox1, operationsError);
+                isValid = false;
+            }
 
             //Purchase order number validation
             string poError = newDV.validatePurchaseOrderNumber(poNumber);


### PR DESCRIPTION
This feature adds validateOperations to DataValidation.cs, quantityError and operationsError to the project.

The validateOperations function is used to check if the items checked in the checkedlist box result in an empty string, if so sends an error message to UpdateRecord.cs.

Now if the user tries to use the UpdateRecord form, errors are visible to the user for the quantity and operations input prompts.

An error will be shown if null, 0, negative or not an integer is inputted for quantity.
An error will be shown if no options are selected for operations.