### PR TITLE
Fix/Add Additional Operations Checkboxes

### DIFF
--- a/KiczanProductionInfoSystem/CreateRecord.Designer.cs
+++ b/KiczanProductionInfoSystem/CreateRecord.Designer.cs
@@ -79,10 +79,11 @@ namespace KiczanProductionInfoSystem
             // 
             this.button1.BackColor = System.Drawing.Color.Green;
             this.button1.ForeColor = System.Drawing.Color.White;
-            this.button1.Location = new System.Drawing.Point(266, 420);
+            this.button1.Location = new System.Drawing.Point(532, 808);
+            this.button1.Margin = new System.Windows.Forms.Padding(6);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(100, 23);
-            this.button1.TabIndex = 0;
+            this.button1.Size = new System.Drawing.Size(200, 44);
+            this.button1.TabIndex = 8;
             this.button1.Text = "Submit";
             this.button1.UseVisualStyleBackColor = false;
             this.button1.Click += new System.EventHandler(this.button1_Click);
@@ -95,11 +96,14 @@ namespace KiczanProductionInfoSystem
             "Laser",
             "Water Jet",
             "Punch",
-            "Press Brake"});
-            this.checkedListBox1.Location = new System.Drawing.Point(393, 305);
+            "Press Brake",
+            "Lathe",
+            "Mill"});
+            this.checkedListBox1.Location = new System.Drawing.Point(786, 557);
+            this.checkedListBox1.Margin = new System.Windows.Forms.Padding(6);
             this.checkedListBox1.Name = "checkedListBox1";
-            this.checkedListBox1.Size = new System.Drawing.Size(120, 64);
-            this.checkedListBox1.TabIndex = 1;
+            this.checkedListBox1.Size = new System.Drawing.Size(236, 200);
+            this.checkedListBox1.TabIndex = 7;
             this.checkedListBox1.SelectedIndexChanged += new System.EventHandler(this.checkedListBox1_SelectedIndexChanged);
             // 
             // errorProvider1
@@ -108,20 +112,20 @@ namespace KiczanProductionInfoSystem
             // 
             // textBoxQuantity
             // 
-            this.textBoxQuantity.Location = new System.Drawing.Point(393, 173);
-            this.textBoxQuantity.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxQuantity.Location = new System.Drawing.Point(786, 333);
+            this.textBoxQuantity.Margin = new System.Windows.Forms.Padding(4);
             this.textBoxQuantity.Name = "textBoxQuantity";
-            this.textBoxQuantity.Size = new System.Drawing.Size(120, 20);
-            this.textBoxQuantity.TabIndex = 3;
+            this.textBoxQuantity.Size = new System.Drawing.Size(236, 31);
+            this.textBoxQuantity.TabIndex = 4;
             // 
             // labelQuantity
             // 
             this.labelQuantity.AutoSize = true;
             this.labelQuantity.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelQuantity.Location = new System.Drawing.Point(307, 176);
-            this.labelQuantity.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelQuantity.Location = new System.Drawing.Point(614, 338);
+            this.labelQuantity.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelQuantity.Name = "labelQuantity";
-            this.labelQuantity.Size = new System.Drawing.Size(46, 13);
+            this.labelQuantity.Size = new System.Drawing.Size(93, 26);
             this.labelQuantity.TabIndex = 2;
             this.labelQuantity.Text = "Quantity";
             // 
@@ -137,10 +141,10 @@ namespace KiczanProductionInfoSystem
             // 
             this.labelOperations.AutoSize = true;
             this.labelOperations.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelOperations.Location = new System.Drawing.Point(310, 325);
-            this.labelOperations.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelOperations.Location = new System.Drawing.Point(614, 625);
+            this.labelOperations.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelOperations.Name = "labelOperations";
-            this.labelOperations.Size = new System.Drawing.Size(58, 13);
+            this.labelOperations.Size = new System.Drawing.Size(118, 26);
             this.labelOperations.TabIndex = 6;
             this.labelOperations.Text = "Operations";
             // 
@@ -148,10 +152,10 @@ namespace KiczanProductionInfoSystem
             // 
             this.button2.BackColor = System.Drawing.Color.Red;
             this.button2.ForeColor = System.Drawing.Color.White;
-            this.button2.Location = new System.Drawing.Point(393, 420);
-            this.button2.Margin = new System.Windows.Forms.Padding(2);
+            this.button2.Location = new System.Drawing.Point(803, 808);
+            this.button2.Margin = new System.Windows.Forms.Padding(4);
             this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(100, 23);
+            this.button2.Size = new System.Drawing.Size(200, 44);
             this.button2.TabIndex = 9;
             this.button2.Text = "Clear";
             this.button2.UseVisualStyleBackColor = false;
@@ -161,10 +165,10 @@ namespace KiczanProductionInfoSystem
             // 
             this.button3.BackColor = System.Drawing.Color.Blue;
             this.button3.ForeColor = System.Drawing.Color.White;
-            this.button3.Location = new System.Drawing.Point(534, 420);
-            this.button3.Margin = new System.Windows.Forms.Padding(2);
+            this.button3.Location = new System.Drawing.Point(1068, 808);
+            this.button3.Margin = new System.Windows.Forms.Padding(4);
             this.button3.Name = "button3";
-            this.button3.Size = new System.Drawing.Size(100, 23);
+            this.button3.Size = new System.Drawing.Size(200, 44);
             this.button3.TabIndex = 10;
             this.button3.Text = "Back to Menu";
             this.button3.UseVisualStyleBackColor = false;
@@ -173,30 +177,30 @@ namespace KiczanProductionInfoSystem
             // labelRecordStatus
             // 
             this.labelRecordStatus.AutoSize = true;
-            this.labelRecordStatus.Location = new System.Drawing.Point(362, 392);
-            this.labelRecordStatus.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelRecordStatus.Location = new System.Drawing.Point(726, 763);
+            this.labelRecordStatus.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelRecordStatus.Name = "labelRecordStatus";
-            this.labelRecordStatus.Size = new System.Drawing.Size(0, 13);
+            this.labelRecordStatus.Size = new System.Drawing.Size(0, 25);
             this.labelRecordStatus.TabIndex = 11;
             // 
             // labelPartNumber
             // 
             this.labelPartNumber.AutoSize = true;
             this.labelPartNumber.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelPartNumber.Location = new System.Drawing.Point(307, 96);
-            this.labelPartNumber.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelPartNumber.Location = new System.Drawing.Point(614, 185);
+            this.labelPartNumber.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelPartNumber.Name = "labelPartNumber";
-            this.labelPartNumber.Size = new System.Drawing.Size(66, 13);
+            this.labelPartNumber.Size = new System.Drawing.Size(136, 26);
             this.labelPartNumber.TabIndex = 12;
             this.labelPartNumber.Text = "Part Number";
             // 
             // textBoxPartNumber
             // 
-            this.textBoxPartNumber.Location = new System.Drawing.Point(393, 93);
-            this.textBoxPartNumber.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxPartNumber.Location = new System.Drawing.Point(786, 179);
+            this.textBoxPartNumber.Margin = new System.Windows.Forms.Padding(4);
             this.textBoxPartNumber.Name = "textBoxPartNumber";
-            this.textBoxPartNumber.Size = new System.Drawing.Size(120, 20);
-            this.textBoxPartNumber.TabIndex = 13;
+            this.textBoxPartNumber.Size = new System.Drawing.Size(236, 31);
+            this.textBoxPartNumber.TabIndex = 2;
             // 
             // errorProviderPartNumber
             // 
@@ -206,78 +210,89 @@ namespace KiczanProductionInfoSystem
             // 
             this.labelPO.AutoSize = true;
             this.labelPO.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelPO.Location = new System.Drawing.Point(307, 135);
+            this.labelPO.Location = new System.Drawing.Point(614, 260);
+            this.labelPO.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelPO.Name = "labelPO";
-            this.labelPO.Size = new System.Drawing.Size(73, 13);
+            this.labelPO.Size = new System.Drawing.Size(151, 26);
             this.labelPO.TabIndex = 15;
             this.labelPO.Text = "Order Number";
             // 
             // textBoxPO
             // 
-            this.textBoxPO.Location = new System.Drawing.Point(393, 132);
+            this.textBoxPO.Location = new System.Drawing.Point(786, 254);
+            this.textBoxPO.Margin = new System.Windows.Forms.Padding(6);
             this.textBoxPO.Name = "textBoxPO";
-            this.textBoxPO.Size = new System.Drawing.Size(120, 20);
-            this.textBoxPO.TabIndex = 16;
+            this.textBoxPO.Size = new System.Drawing.Size(236, 31);
+            this.textBoxPO.TabIndex = 3;
             // 
             // labelPartNumberError
             // 
             this.labelPartNumberError.AutoSize = true;
-            this.labelPartNumberError.Location = new System.Drawing.Point(72, 102);
+            this.labelPartNumberError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelPartNumberError.Location = new System.Drawing.Point(144, 179);
+            this.labelPartNumberError.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelPartNumberError.Name = "labelPartNumberError";
-            this.labelPartNumberError.Size = new System.Drawing.Size(0, 13);
+            this.labelPartNumberError.Size = new System.Drawing.Size(0, 24);
             this.labelPartNumberError.TabIndex = 17;
             // 
             // labelQuantityError
             // 
             this.labelQuantityError.AutoSize = true;
-            this.labelQuantityError.Location = new System.Drawing.Point(72, 186);
+            this.labelQuantityError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelQuantityError.Location = new System.Drawing.Point(144, 333);
+            this.labelQuantityError.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelQuantityError.Name = "labelQuantityError";
-            this.labelQuantityError.Size = new System.Drawing.Size(0, 13);
+            this.labelQuantityError.Size = new System.Drawing.Size(0, 24);
             this.labelQuantityError.TabIndex = 18;
             // 
             // labelOperationsError
             // 
             this.labelOperationsError.AutoSize = true;
-            this.labelOperationsError.Location = new System.Drawing.Point(72, 339);
+            this.labelOperationsError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelOperationsError.Location = new System.Drawing.Point(144, 626);
+            this.labelOperationsError.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelOperationsError.Name = "labelOperationsError";
-            this.labelOperationsError.Size = new System.Drawing.Size(0, 13);
+            this.labelOperationsError.Size = new System.Drawing.Size(0, 24);
             this.labelOperationsError.TabIndex = 19;
             // 
             // labelPOError
             // 
             this.labelPOError.AutoSize = true;
-            this.labelPOError.Location = new System.Drawing.Point(72, 145);
+            this.labelPOError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelPOError.Location = new System.Drawing.Point(144, 254);
+            this.labelPOError.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelPOError.Name = "labelPOError";
-            this.labelPOError.Size = new System.Drawing.Size(0, 13);
+            this.labelPOError.Size = new System.Drawing.Size(0, 24);
             this.labelPOError.TabIndex = 20;
             // 
             // operatorComboBox
             // 
             this.operatorComboBox.FormattingEnabled = true;
-            this.operatorComboBox.Location = new System.Drawing.Point(393, 55);
-            this.operatorComboBox.Margin = new System.Windows.Forms.Padding(2);
+            this.operatorComboBox.Location = new System.Drawing.Point(786, 106);
+            this.operatorComboBox.Margin = new System.Windows.Forms.Padding(4);
             this.operatorComboBox.Name = "operatorComboBox";
-            this.operatorComboBox.Size = new System.Drawing.Size(120, 21);
-            this.operatorComboBox.TabIndex = 21;
+            this.operatorComboBox.Size = new System.Drawing.Size(236, 33);
+            this.operatorComboBox.TabIndex = 1;
             // 
             // labelOperator
             // 
             this.labelOperator.AutoSize = true;
             this.labelOperator.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelOperator.Location = new System.Drawing.Point(307, 55);
-            this.labelOperator.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelOperator.Location = new System.Drawing.Point(614, 106);
+            this.labelOperator.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelOperator.Name = "labelOperator";
-            this.labelOperator.Size = new System.Drawing.Size(48, 13);
+            this.labelOperator.Size = new System.Drawing.Size(97, 26);
             this.labelOperator.TabIndex = 22;
             this.labelOperator.Text = "Operator";
             // 
             // labelOperatorError
             // 
             this.labelOperatorError.AutoSize = true;
-            this.labelOperatorError.Location = new System.Drawing.Point(72, 58);
-            this.labelOperatorError.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelOperatorError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelOperatorError.Location = new System.Drawing.Point(144, 106);
+            this.labelOperatorError.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelOperatorError.Name = "labelOperatorError";
-            this.labelOperatorError.Size = new System.Drawing.Size(0, 13);
+            this.labelOperatorError.Size = new System.Drawing.Size(0, 24);
             this.labelOperatorError.TabIndex = 23;
             // 
             // errorProviderOperator
@@ -287,31 +302,32 @@ namespace KiczanProductionInfoSystem
             // labelCustomerError
             // 
             this.labelCustomerError.AutoSize = true;
-            this.labelCustomerError.Location = new System.Drawing.Point(72, 16);
-            this.labelCustomerError.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelCustomerError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelCustomerError.Location = new System.Drawing.Point(144, 23);
+            this.labelCustomerError.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelCustomerError.Name = "labelCustomerError";
-            this.labelCustomerError.Size = new System.Drawing.Size(0, 13);
+            this.labelCustomerError.Size = new System.Drawing.Size(0, 24);
             this.labelCustomerError.TabIndex = 24;
             // 
             // labelCustomer
             // 
             this.labelCustomer.AutoSize = true;
             this.labelCustomer.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelCustomer.Location = new System.Drawing.Point(307, 12);
-            this.labelCustomer.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelCustomer.Location = new System.Drawing.Point(614, 23);
+            this.labelCustomer.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelCustomer.Name = "labelCustomer";
-            this.labelCustomer.Size = new System.Drawing.Size(51, 13);
+            this.labelCustomer.Size = new System.Drawing.Size(107, 26);
             this.labelCustomer.TabIndex = 25;
             this.labelCustomer.Text = "Customer";
             // 
             // customerComboBox
             // 
             this.customerComboBox.FormattingEnabled = true;
-            this.customerComboBox.Location = new System.Drawing.Point(393, 12);
-            this.customerComboBox.Margin = new System.Windows.Forms.Padding(2);
+            this.customerComboBox.Location = new System.Drawing.Point(786, 23);
+            this.customerComboBox.Margin = new System.Windows.Forms.Padding(4);
             this.customerComboBox.Name = "customerComboBox";
-            this.customerComboBox.Size = new System.Drawing.Size(120, 21);
-            this.customerComboBox.TabIndex = 26;
+            this.customerComboBox.Size = new System.Drawing.Size(236, 33);
+            this.customerComboBox.TabIndex = 0;
             // 
             // errorProviderCustomer
             // 
@@ -319,20 +335,20 @@ namespace KiczanProductionInfoSystem
             // 
             // textBoxDateReceived
             // 
-            this.textBoxDateReceived.Location = new System.Drawing.Point(393, 217);
-            this.textBoxDateReceived.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxDateReceived.Location = new System.Drawing.Point(786, 417);
+            this.textBoxDateReceived.Margin = new System.Windows.Forms.Padding(4);
             this.textBoxDateReceived.Name = "textBoxDateReceived";
-            this.textBoxDateReceived.Size = new System.Drawing.Size(120, 20);
-            this.textBoxDateReceived.TabIndex = 27;
+            this.textBoxDateReceived.Size = new System.Drawing.Size(236, 31);
+            this.textBoxDateReceived.TabIndex = 5;
             // 
             // labelDateReceived
             // 
             this.labelDateReceived.AutoSize = true;
             this.labelDateReceived.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelDateReceived.Location = new System.Drawing.Point(307, 220);
-            this.labelDateReceived.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelDateReceived.Location = new System.Drawing.Point(614, 423);
+            this.labelDateReceived.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelDateReceived.Name = "labelDateReceived";
-            this.labelDateReceived.Size = new System.Drawing.Size(79, 13);
+            this.labelDateReceived.Size = new System.Drawing.Size(153, 25);
             this.labelDateReceived.TabIndex = 28;
             this.labelDateReceived.Text = "Date Received";
             // 
@@ -343,42 +359,47 @@ namespace KiczanProductionInfoSystem
             // labelDateReceivedError
             // 
             this.labelDateReceivedError.AutoSize = true;
-            this.labelDateReceivedError.Location = new System.Drawing.Point(72, 226);
-            this.labelDateReceivedError.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelDateReceivedError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelDateReceivedError.Location = new System.Drawing.Point(144, 417);
+            this.labelDateReceivedError.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelDateReceivedError.Name = "labelDateReceivedError";
-            this.labelDateReceivedError.Size = new System.Drawing.Size(0, 13);
+            this.labelDateReceivedError.Size = new System.Drawing.Size(0, 24);
             this.labelDateReceivedError.TabIndex = 29;
             // 
             // labelDueDate
             // 
             this.labelDueDate.AutoSize = true;
             this.labelDueDate.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelDueDate.Location = new System.Drawing.Point(310, 265);
+            this.labelDueDate.Location = new System.Drawing.Point(614, 501);
+            this.labelDueDate.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelDueDate.Name = "labelDueDate";
-            this.labelDueDate.Size = new System.Drawing.Size(53, 13);
+            this.labelDueDate.Size = new System.Drawing.Size(104, 26);
             this.labelDueDate.TabIndex = 30;
             this.labelDueDate.Text = "Due Date";
             // 
             // textboxDueDate
             // 
-            this.textboxDueDate.Location = new System.Drawing.Point(393, 258);
+            this.textboxDueDate.Location = new System.Drawing.Point(786, 496);
+            this.textboxDueDate.Margin = new System.Windows.Forms.Padding(6);
             this.textboxDueDate.Name = "textboxDueDate";
-            this.textboxDueDate.Size = new System.Drawing.Size(120, 20);
-            this.textboxDueDate.TabIndex = 31;
+            this.textboxDueDate.Size = new System.Drawing.Size(236, 31);
+            this.textboxDueDate.TabIndex = 6;
             // 
             // labelDueDateError
             // 
             this.labelDueDateError.AutoSize = true;
-            this.labelDueDateError.Location = new System.Drawing.Point(72, 275);
+            this.labelDueDateError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelDueDateError.Location = new System.Drawing.Point(144, 496);
+            this.labelDueDateError.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelDueDateError.Name = "labelDueDateError";
-            this.labelDueDateError.Size = new System.Drawing.Size(0, 13);
+            this.labelDueDateError.Size = new System.Drawing.Size(0, 24);
             this.labelDueDateError.TabIndex = 32;
             // 
             // CreateRecord
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.ClientSize = new System.Drawing.Size(1600, 865);
             this.Controls.Add(this.labelDueDateError);
             this.Controls.Add(this.textboxDueDate);
             this.Controls.Add(this.labelDueDate);
@@ -407,6 +428,7 @@ namespace KiczanProductionInfoSystem
             this.Controls.Add(this.labelQuantity);
             this.Controls.Add(this.checkedListBox1);
             this.Controls.Add(this.button1);
+            this.Margin = new System.Windows.Forms.Padding(6);
             this.Name = "CreateRecord";
             this.Text = "CreateRecord";
             this.Load += new System.EventHandler(this.CreateRecord_Load);

--- a/KiczanProductionInfoSystem/CreateRecord.cs
+++ b/KiczanProductionInfoSystem/CreateRecord.cs
@@ -86,9 +86,6 @@ namespace KiczanProductionInfoSystem
             //validation flag
             bool isValid = true;
 
-            Console.WriteLine(opID);
-            Console.WriteLine(custID);
-
             // Clear all error labels first
             labelPartNumberError.Text = "";
             labelQuantityError.Text = "";
@@ -161,9 +158,7 @@ namespace KiczanProductionInfoSystem
                     checkedItems.Add(item.ToString());
                     //save formated checklist options to pass as a paramater into insert statement
                     checkedOperations = string.Join(", ", checkedItems);
-                    Console.WriteLine(checkedOperations);
                 }
-
             }
 
             //purchase order number validation

--- a/KiczanProductionInfoSystem/CreateRecord.cs
+++ b/KiczanProductionInfoSystem/CreateRecord.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Globalization;
 using System.Windows.Forms;
 
@@ -127,7 +128,7 @@ namespace KiczanProductionInfoSystem
             //part number validation
             if (!newDV.validatePartNumber(partNumber))
             {
-                string message = "Part Number must not be empty and may only \n contain letters, numbers, or hyphen.";
+                string message = "Record not Complete!\nPart Number must not be empty and may only\ncontain letters, numbers, or hyphen.";
                 labelPartNumberError.Text = message;
                 errorProviderPartNumber.SetError(textBoxPartNumber, message);
                 isValid = false;
@@ -145,7 +146,7 @@ namespace KiczanProductionInfoSystem
             //operations validation
             if (checkedListBox1.CheckedItems.Count == 0)
             {
-                string message = "Please select at least one operation.";
+                string message = "Record not Complete!\nPlease select at least one operation.";
                 labelOperationsError.Text = message;
                 errorProvider2.SetError(checkedListBox1, message);
                 isValid = false;
@@ -257,6 +258,6 @@ namespace KiczanProductionInfoSystem
         {
 
         }
-        
+
     }
 }

--- a/KiczanProductionInfoSystem/DataValidation.cs
+++ b/KiczanProductionInfoSystem/DataValidation.cs
@@ -110,15 +110,15 @@ namespace KiczanProductionInfoSystem
 
             if (string.IsNullOrEmpty(input))
             {
-                message = "Record not Complete!\nQuantity must not be empty,\nplease enter a value.";
+                message = "Record not complete!\nQuantity must not be empty,\nplease enter a value.";
             }
             else if (int.TryParse(input, out quantity) == false)
             {
-                message = "Record not Complete!\nQuantity must be\na numerical value.";
+                message = "Record not complete!\nQuantity must be\na numerical value.";
             }
             else if (quantity <= 0)
             {
-                message = "Record not Complete!\nQuantity must be an integer \ngreater than or equal to 1.";
+                message = "Record not complete!\nQuantity must be an integer \ngreater than or equal to 1.";
             }
             return message;
         }
@@ -130,13 +130,13 @@ namespace KiczanProductionInfoSystem
             poNumber = poNumber.Trim();
 
             if (string.IsNullOrWhiteSpace(poNumber))
-                message = "Purchase Order Number \nis required.";
+                message = "Record not complete!\nPurchase Order Number \nis required.";
 
             else if (poNumber.Length < 4 || poNumber.Length > 20)
-                message = "Order Number must be between \n4 and 20 characters.";
+                message = "Record not complete!\nPurchase Order Number must be between \n4 and 20 characters.";
 
             else if (!Regex.IsMatch(poNumber, @"^[a-zA-Z0-9\-]+$"))
-                message = "Order Number can only contain \nletters, numbers, and hyphens.";
+                message = "Record not complete!\nPurchase Order Number can only contain \nletters, numbers, and hyphens.";
 
             return message;
         }
@@ -148,7 +148,7 @@ namespace KiczanProductionInfoSystem
 
             if(input == 0)
             {
-                message = "Record not Complete!\nPlease select an Operator.";
+                message = "Record not complete!\nPlease select an Operator.";
             }
 
             return message;
@@ -161,7 +161,7 @@ namespace KiczanProductionInfoSystem
 
             if (string.IsNullOrWhiteSpace(input))
             {
-                message = "Record not Complete!\nPlease select at least one Operation.";
+                message = "Record not complete!\nPlease select at least one Operation.";
             }
 
             return message;
@@ -175,7 +175,7 @@ namespace KiczanProductionInfoSystem
 
             if (string.IsNullOrWhiteSpace(input))
             {
-                message = "Record not Complete!\nDate must not be empty,\nplease enter a value.";
+                message = "Record not complete!\nDate must not be empty,\nplease enter a value.";
             }
             else if (!DateTime.TryParseExact(
                 input,
@@ -184,7 +184,7 @@ namespace KiczanProductionInfoSystem
                 DateTimeStyles.None,
                 out parsedDate))
             {
-                message = "Record not Complete!\nDate must be in MM/DD/YYYY format.";
+                message = "Record not complete!\nDate must be in MM/DD/YYYY format.";
             }
 
             return message;
@@ -198,7 +198,7 @@ namespace KiczanProductionInfoSystem
 
             if (string.IsNullOrWhiteSpace(dueDateText))
             {
-                message = "Record not Complete!\nDate must not be empty,\nplease enter a value.";
+                message = "Record not complete!\nDate must not be empty,\nplease enter a value.";
             }
             else if (!DateTime.TryParseExact(
                 dueDateText,
@@ -207,7 +207,7 @@ namespace KiczanProductionInfoSystem
                 DateTimeStyles.None,
                 out dueDate))
             {
-                message = "Record not Complete!\nDate must be in MM/DD/YYYY format.";
+                message = "Record not complete!\nDate must be in MM/DD/YYYY format.";
             }
             return message;
         }
@@ -219,7 +219,7 @@ namespace KiczanProductionInfoSystem
 
             if (input == 0)
             {
-                message = "Record not Complete!\nPlease select a Customer.";
+                message = "Record not complete!\nPlease select a Customer.";
             }
 
             return message;

--- a/KiczanProductionInfoSystem/KiczanProductionInfoSystem.csproj
+++ b/KiczanProductionInfoSystem/KiczanProductionInfoSystem.csproj
@@ -136,6 +136,9 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
+    <EmbeddedResource Include="UpdateRecord.resx">
+      <DependentUpon>UpdateRecord.cs</DependentUpon>
+    </EmbeddedResource>
     <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/KiczanProductionInfoSystem/Program.cs
+++ b/KiczanProductionInfoSystem/Program.cs
@@ -16,8 +16,8 @@ namespace KiczanProductionInfoSystem
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-
         
+
             //Create new DAO Object for user authentication.
             DAO newDAO = new DAO();
 

--- a/KiczanProductionInfoSystem/UpdateRecord.Designer.cs
+++ b/KiczanProductionInfoSystem/UpdateRecord.Designer.cs
@@ -79,10 +79,11 @@ namespace KiczanProductionInfoSystem
             // 
             this.button1.BackColor = System.Drawing.Color.Green;
             this.button1.ForeColor = System.Drawing.Color.White;
-            this.button1.Location = new System.Drawing.Point(266, 420);
+            this.button1.Location = new System.Drawing.Point(532, 808);
+            this.button1.Margin = new System.Windows.Forms.Padding(6);
             this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(100, 23);
-            this.button1.TabIndex = 0;
+            this.button1.Size = new System.Drawing.Size(200, 44);
+            this.button1.TabIndex = 8;
             this.button1.Text = "Submit";
             this.button1.UseVisualStyleBackColor = false;
             this.button1.Click += new System.EventHandler(this.button1_Click);
@@ -95,11 +96,14 @@ namespace KiczanProductionInfoSystem
             "Laser",
             "Water Jet",
             "Punch",
-            "Press Brake"});
-            this.checkedListBox1.Location = new System.Drawing.Point(393, 305);
+            "Press Brake",
+            "Lathe",
+            "Mill"});
+            this.checkedListBox1.Location = new System.Drawing.Point(786, 560);
+            this.checkedListBox1.Margin = new System.Windows.Forms.Padding(6);
             this.checkedListBox1.Name = "checkedListBox1";
-            this.checkedListBox1.Size = new System.Drawing.Size(120, 64);
-            this.checkedListBox1.TabIndex = 1;
+            this.checkedListBox1.Size = new System.Drawing.Size(236, 200);
+            this.checkedListBox1.TabIndex = 7;
             this.checkedListBox1.SelectedIndexChanged += new System.EventHandler(this.checkedListBox1_SelectedIndexChanged);
             // 
             // errorProvider1
@@ -108,20 +112,20 @@ namespace KiczanProductionInfoSystem
             // 
             // textBoxQuantity
             // 
-            this.textBoxQuantity.Location = new System.Drawing.Point(393, 173);
-            this.textBoxQuantity.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxQuantity.Location = new System.Drawing.Point(786, 333);
+            this.textBoxQuantity.Margin = new System.Windows.Forms.Padding(4);
             this.textBoxQuantity.Name = "textBoxQuantity";
-            this.textBoxQuantity.Size = new System.Drawing.Size(120, 20);
-            this.textBoxQuantity.TabIndex = 3;
+            this.textBoxQuantity.Size = new System.Drawing.Size(236, 31);
+            this.textBoxQuantity.TabIndex = 4;
             // 
             // labelQuantity
             // 
             this.labelQuantity.AutoSize = true;
             this.labelQuantity.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelQuantity.Location = new System.Drawing.Point(307, 176);
-            this.labelQuantity.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelQuantity.Location = new System.Drawing.Point(614, 338);
+            this.labelQuantity.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelQuantity.Name = "labelQuantity";
-            this.labelQuantity.Size = new System.Drawing.Size(46, 13);
+            this.labelQuantity.Size = new System.Drawing.Size(93, 26);
             this.labelQuantity.TabIndex = 2;
             this.labelQuantity.Text = "Quantity";
             // 
@@ -137,10 +141,10 @@ namespace KiczanProductionInfoSystem
             // 
             this.labelOperations.AutoSize = true;
             this.labelOperations.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelOperations.Location = new System.Drawing.Point(310, 325);
-            this.labelOperations.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelOperations.Location = new System.Drawing.Point(614, 623);
+            this.labelOperations.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelOperations.Name = "labelOperations";
-            this.labelOperations.Size = new System.Drawing.Size(58, 13);
+            this.labelOperations.Size = new System.Drawing.Size(118, 26);
             this.labelOperations.TabIndex = 6;
             this.labelOperations.Text = "Operations";
             // 
@@ -148,10 +152,10 @@ namespace KiczanProductionInfoSystem
             // 
             this.button2.BackColor = System.Drawing.Color.Red;
             this.button2.ForeColor = System.Drawing.Color.White;
-            this.button2.Location = new System.Drawing.Point(393, 420);
-            this.button2.Margin = new System.Windows.Forms.Padding(2);
+            this.button2.Location = new System.Drawing.Point(804, 808);
+            this.button2.Margin = new System.Windows.Forms.Padding(4);
             this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(100, 23);
+            this.button2.Size = new System.Drawing.Size(200, 44);
             this.button2.TabIndex = 9;
             this.button2.Text = "Clear";
             this.button2.UseVisualStyleBackColor = false;
@@ -161,10 +165,10 @@ namespace KiczanProductionInfoSystem
             // 
             this.button3.BackColor = System.Drawing.Color.Blue;
             this.button3.ForeColor = System.Drawing.Color.White;
-            this.button3.Location = new System.Drawing.Point(534, 420);
-            this.button3.Margin = new System.Windows.Forms.Padding(2);
+            this.button3.Location = new System.Drawing.Point(1068, 808);
+            this.button3.Margin = new System.Windows.Forms.Padding(4);
             this.button3.Name = "button3";
-            this.button3.Size = new System.Drawing.Size(100, 23);
+            this.button3.Size = new System.Drawing.Size(200, 44);
             this.button3.TabIndex = 10;
             this.button3.Text = "Back to Menu";
             this.button3.UseVisualStyleBackColor = false;
@@ -173,30 +177,30 @@ namespace KiczanProductionInfoSystem
             // labelRecordStatus
             // 
             this.labelRecordStatus.AutoSize = true;
-            this.labelRecordStatus.Location = new System.Drawing.Point(362, 392);
-            this.labelRecordStatus.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelRecordStatus.Location = new System.Drawing.Point(724, 754);
+            this.labelRecordStatus.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelRecordStatus.Name = "labelRecordStatus";
-            this.labelRecordStatus.Size = new System.Drawing.Size(0, 13);
+            this.labelRecordStatus.Size = new System.Drawing.Size(0, 25);
             this.labelRecordStatus.TabIndex = 11;
             // 
             // labelPartNumber
             // 
             this.labelPartNumber.AutoSize = true;
             this.labelPartNumber.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelPartNumber.Location = new System.Drawing.Point(307, 96);
-            this.labelPartNumber.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelPartNumber.Location = new System.Drawing.Point(614, 185);
+            this.labelPartNumber.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelPartNumber.Name = "labelPartNumber";
-            this.labelPartNumber.Size = new System.Drawing.Size(66, 13);
+            this.labelPartNumber.Size = new System.Drawing.Size(136, 26);
             this.labelPartNumber.TabIndex = 12;
             this.labelPartNumber.Text = "Part Number";
             // 
             // textBoxPartNumber
             // 
-            this.textBoxPartNumber.Location = new System.Drawing.Point(393, 93);
-            this.textBoxPartNumber.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxPartNumber.Location = new System.Drawing.Point(786, 179);
+            this.textBoxPartNumber.Margin = new System.Windows.Forms.Padding(4);
             this.textBoxPartNumber.Name = "textBoxPartNumber";
-            this.textBoxPartNumber.Size = new System.Drawing.Size(120, 20);
-            this.textBoxPartNumber.TabIndex = 13;
+            this.textBoxPartNumber.Size = new System.Drawing.Size(236, 31);
+            this.textBoxPartNumber.TabIndex = 2;
             // 
             // errorProviderPartNumber
             // 
@@ -206,78 +210,89 @@ namespace KiczanProductionInfoSystem
             // 
             this.labelPO.AutoSize = true;
             this.labelPO.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelPO.Location = new System.Drawing.Point(307, 135);
+            this.labelPO.Location = new System.Drawing.Point(614, 260);
+            this.labelPO.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelPO.Name = "labelPO";
-            this.labelPO.Size = new System.Drawing.Size(73, 13);
+            this.labelPO.Size = new System.Drawing.Size(151, 26);
             this.labelPO.TabIndex = 15;
             this.labelPO.Text = "Order Number";
             // 
             // textBoxPO
             // 
-            this.textBoxPO.Location = new System.Drawing.Point(393, 132);
+            this.textBoxPO.Location = new System.Drawing.Point(786, 254);
+            this.textBoxPO.Margin = new System.Windows.Forms.Padding(6);
             this.textBoxPO.Name = "textBoxPO";
-            this.textBoxPO.Size = new System.Drawing.Size(120, 20);
-            this.textBoxPO.TabIndex = 16;
+            this.textBoxPO.Size = new System.Drawing.Size(236, 31);
+            this.textBoxPO.TabIndex = 3;
             // 
             // labelPartNumberError
             // 
             this.labelPartNumberError.AutoSize = true;
-            this.labelPartNumberError.Location = new System.Drawing.Point(72, 102);
+            this.labelPartNumberError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelPartNumberError.Location = new System.Drawing.Point(144, 179);
+            this.labelPartNumberError.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelPartNumberError.Name = "labelPartNumberError";
-            this.labelPartNumberError.Size = new System.Drawing.Size(0, 13);
+            this.labelPartNumberError.Size = new System.Drawing.Size(0, 24);
             this.labelPartNumberError.TabIndex = 17;
             // 
             // labelQuantityError
             // 
             this.labelQuantityError.AutoSize = true;
-            this.labelQuantityError.Location = new System.Drawing.Point(72, 186);
+            this.labelQuantityError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelQuantityError.Location = new System.Drawing.Point(144, 333);
+            this.labelQuantityError.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelQuantityError.Name = "labelQuantityError";
-            this.labelQuantityError.Size = new System.Drawing.Size(0, 13);
+            this.labelQuantityError.Size = new System.Drawing.Size(0, 24);
             this.labelQuantityError.TabIndex = 18;
             // 
             // labelOperationsError
             // 
             this.labelOperationsError.AutoSize = true;
-            this.labelOperationsError.Location = new System.Drawing.Point(72, 339);
+            this.labelOperationsError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelOperationsError.Location = new System.Drawing.Point(144, 625);
+            this.labelOperationsError.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelOperationsError.Name = "labelOperationsError";
-            this.labelOperationsError.Size = new System.Drawing.Size(0, 13);
+            this.labelOperationsError.Size = new System.Drawing.Size(0, 24);
             this.labelOperationsError.TabIndex = 19;
             // 
             // labelPOError
             // 
             this.labelPOError.AutoSize = true;
-            this.labelPOError.Location = new System.Drawing.Point(72, 145);
+            this.labelPOError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelPOError.Location = new System.Drawing.Point(144, 254);
+            this.labelPOError.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelPOError.Name = "labelPOError";
-            this.labelPOError.Size = new System.Drawing.Size(0, 13);
+            this.labelPOError.Size = new System.Drawing.Size(0, 24);
             this.labelPOError.TabIndex = 20;
             // 
             // operatorComboBox
             // 
             this.operatorComboBox.FormattingEnabled = true;
-            this.operatorComboBox.Location = new System.Drawing.Point(393, 55);
-            this.operatorComboBox.Margin = new System.Windows.Forms.Padding(2);
+            this.operatorComboBox.Location = new System.Drawing.Point(786, 106);
+            this.operatorComboBox.Margin = new System.Windows.Forms.Padding(4);
             this.operatorComboBox.Name = "operatorComboBox";
-            this.operatorComboBox.Size = new System.Drawing.Size(120, 21);
-            this.operatorComboBox.TabIndex = 21;
+            this.operatorComboBox.Size = new System.Drawing.Size(236, 33);
+            this.operatorComboBox.TabIndex = 1;
             // 
             // labelOperator
             // 
             this.labelOperator.AutoSize = true;
             this.labelOperator.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelOperator.Location = new System.Drawing.Point(307, 55);
-            this.labelOperator.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelOperator.Location = new System.Drawing.Point(614, 106);
+            this.labelOperator.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelOperator.Name = "labelOperator";
-            this.labelOperator.Size = new System.Drawing.Size(48, 13);
+            this.labelOperator.Size = new System.Drawing.Size(97, 26);
             this.labelOperator.TabIndex = 22;
             this.labelOperator.Text = "Operator";
             // 
             // labelOperatorError
             // 
             this.labelOperatorError.AutoSize = true;
-            this.labelOperatorError.Location = new System.Drawing.Point(72, 58);
-            this.labelOperatorError.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelOperatorError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelOperatorError.Location = new System.Drawing.Point(144, 106);
+            this.labelOperatorError.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelOperatorError.Name = "labelOperatorError";
-            this.labelOperatorError.Size = new System.Drawing.Size(0, 13);
+            this.labelOperatorError.Size = new System.Drawing.Size(0, 24);
             this.labelOperatorError.TabIndex = 23;
             // 
             // errorProviderOperator
@@ -287,31 +302,32 @@ namespace KiczanProductionInfoSystem
             // labelCustomerError
             // 
             this.labelCustomerError.AutoSize = true;
-            this.labelCustomerError.Location = new System.Drawing.Point(72, 16);
-            this.labelCustomerError.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelCustomerError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelCustomerError.Location = new System.Drawing.Point(144, 23);
+            this.labelCustomerError.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelCustomerError.Name = "labelCustomerError";
-            this.labelCustomerError.Size = new System.Drawing.Size(0, 13);
+            this.labelCustomerError.Size = new System.Drawing.Size(0, 24);
             this.labelCustomerError.TabIndex = 24;
             // 
             // labelCustomer
             // 
             this.labelCustomer.AutoSize = true;
             this.labelCustomer.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelCustomer.Location = new System.Drawing.Point(307, 12);
-            this.labelCustomer.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelCustomer.Location = new System.Drawing.Point(614, 23);
+            this.labelCustomer.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelCustomer.Name = "labelCustomer";
-            this.labelCustomer.Size = new System.Drawing.Size(51, 13);
+            this.labelCustomer.Size = new System.Drawing.Size(107, 26);
             this.labelCustomer.TabIndex = 25;
             this.labelCustomer.Text = "Customer";
             // 
             // customerComboBox
             // 
             this.customerComboBox.FormattingEnabled = true;
-            this.customerComboBox.Location = new System.Drawing.Point(393, 12);
-            this.customerComboBox.Margin = new System.Windows.Forms.Padding(2);
+            this.customerComboBox.Location = new System.Drawing.Point(786, 23);
+            this.customerComboBox.Margin = new System.Windows.Forms.Padding(4);
             this.customerComboBox.Name = "customerComboBox";
-            this.customerComboBox.Size = new System.Drawing.Size(120, 21);
-            this.customerComboBox.TabIndex = 26;
+            this.customerComboBox.Size = new System.Drawing.Size(236, 33);
+            this.customerComboBox.TabIndex = 0;
             // 
             // errorProviderCustomer
             // 
@@ -319,20 +335,20 @@ namespace KiczanProductionInfoSystem
             // 
             // textBoxDateReceived
             // 
-            this.textBoxDateReceived.Location = new System.Drawing.Point(393, 217);
-            this.textBoxDateReceived.Margin = new System.Windows.Forms.Padding(2);
+            this.textBoxDateReceived.Location = new System.Drawing.Point(786, 417);
+            this.textBoxDateReceived.Margin = new System.Windows.Forms.Padding(4);
             this.textBoxDateReceived.Name = "textBoxDateReceived";
-            this.textBoxDateReceived.Size = new System.Drawing.Size(120, 20);
-            this.textBoxDateReceived.TabIndex = 27;
+            this.textBoxDateReceived.Size = new System.Drawing.Size(236, 31);
+            this.textBoxDateReceived.TabIndex = 5;
             // 
             // labelDateReceived
             // 
             this.labelDateReceived.AutoSize = true;
             this.labelDateReceived.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelDateReceived.Location = new System.Drawing.Point(307, 220);
-            this.labelDateReceived.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelDateReceived.Location = new System.Drawing.Point(614, 423);
+            this.labelDateReceived.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelDateReceived.Name = "labelDateReceived";
-            this.labelDateReceived.Size = new System.Drawing.Size(79, 13);
+            this.labelDateReceived.Size = new System.Drawing.Size(153, 25);
             this.labelDateReceived.TabIndex = 28;
             this.labelDateReceived.Text = "Date Received";
             // 
@@ -343,42 +359,47 @@ namespace KiczanProductionInfoSystem
             // labelDateReceivedError
             // 
             this.labelDateReceivedError.AutoSize = true;
-            this.labelDateReceivedError.Location = new System.Drawing.Point(72, 226);
-            this.labelDateReceivedError.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.labelDateReceivedError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelDateReceivedError.Location = new System.Drawing.Point(144, 417);
+            this.labelDateReceivedError.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.labelDateReceivedError.Name = "labelDateReceivedError";
-            this.labelDateReceivedError.Size = new System.Drawing.Size(0, 13);
+            this.labelDateReceivedError.Size = new System.Drawing.Size(0, 24);
             this.labelDateReceivedError.TabIndex = 29;
             // 
             // labelDueDate
             // 
             this.labelDueDate.AutoSize = true;
             this.labelDueDate.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Underline, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.labelDueDate.Location = new System.Drawing.Point(310, 265);
+            this.labelDueDate.Location = new System.Drawing.Point(614, 501);
+            this.labelDueDate.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelDueDate.Name = "labelDueDate";
-            this.labelDueDate.Size = new System.Drawing.Size(53, 13);
+            this.labelDueDate.Size = new System.Drawing.Size(104, 26);
             this.labelDueDate.TabIndex = 30;
             this.labelDueDate.Text = "Due Date";
             // 
             // textboxDueDate
             // 
-            this.textboxDueDate.Location = new System.Drawing.Point(393, 258);
+            this.textboxDueDate.Location = new System.Drawing.Point(786, 496);
+            this.textboxDueDate.Margin = new System.Windows.Forms.Padding(6);
             this.textboxDueDate.Name = "textboxDueDate";
-            this.textboxDueDate.Size = new System.Drawing.Size(120, 20);
-            this.textboxDueDate.TabIndex = 31;
+            this.textboxDueDate.Size = new System.Drawing.Size(236, 31);
+            this.textboxDueDate.TabIndex = 6;
             // 
             // labelDueDateError
             // 
             this.labelDueDateError.AutoSize = true;
-            this.labelDueDateError.Location = new System.Drawing.Point(72, 275);
+            this.labelDueDateError.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.125F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelDueDateError.Location = new System.Drawing.Point(144, 496);
+            this.labelDueDateError.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
             this.labelDueDateError.Name = "labelDueDateError";
-            this.labelDueDateError.Size = new System.Drawing.Size(0, 13);
+            this.labelDueDateError.Size = new System.Drawing.Size(0, 24);
             this.labelDueDateError.TabIndex = 32;
             // 
             // UpdateRecord
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(12F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
+            this.ClientSize = new System.Drawing.Size(1600, 865);
             this.Controls.Add(this.labelDueDateError);
             this.Controls.Add(this.textboxDueDate);
             this.Controls.Add(this.labelDueDate);
@@ -407,6 +428,7 @@ namespace KiczanProductionInfoSystem
             this.Controls.Add(this.labelQuantity);
             this.Controls.Add(this.checkedListBox1);
             this.Controls.Add(this.button1);
+            this.Margin = new System.Windows.Forms.Padding(6);
             this.Name = "UpdateRecord";
             this.Text = "UpdateRecord";
             this.Load += new System.EventHandler(this.UpdateRecord_Load);
@@ -419,6 +441,7 @@ namespace KiczanProductionInfoSystem
             ((System.ComponentModel.ISupportInitialize)(this.errorProviderDateReceived)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
+
         }
 
         #endregion

--- a/KiczanProductionInfoSystem/UpdateRecord.cs
+++ b/KiczanProductionInfoSystem/UpdateRecord.cs
@@ -27,8 +27,6 @@ namespace KiczanProductionInfoSystem
             //Set the customers List object to be populated with the list returned by GetCustomers().
             customers = newDAO.GetCustomers();
            
-           
-
             //Bind operatorComboBox datasource to the operators list.
             operatorComboBox.DataSource = operators;
 
@@ -119,10 +117,6 @@ namespace KiczanProductionInfoSystem
             //Create new DataValidation Object for input validation.
             DataValidation newDV = new DataValidation();
 
-
-            
-
-
             //Get part number value
             string partNumber = textBoxPartNumber.Text;
 
@@ -143,15 +137,9 @@ namespace KiczanProductionInfoSystem
 
             //Get the CUSTOMER_ID from customerComboBox
             int custID = Convert.ToInt32(customerComboBox.SelectedValue);
-            //Set the partID for the update query.
-            
-
+    
             //validation flag
             bool isValid = true;
-
-            Console.WriteLine(opID);
-            Console.WriteLine(custID);
-            
 
             // Clear all error labels first
             labelPartNumberError.Text = "";
@@ -171,8 +159,7 @@ namespace KiczanProductionInfoSystem
             errorProvider2.Clear();
             errorProvider3.Clear();
 
-            //TO DO: Customer validation.
-
+            //Customer validation.
             string customerError = newDV.validateCustomerSelection(custID);
 
             if (!string.IsNullOrEmpty(customerError))
@@ -182,8 +169,7 @@ namespace KiczanProductionInfoSystem
                 isValid = false;
             }
 
-            //TO DO: Operator validation.
-
+            //Operator validation.
             string operatorError = newDV.validateOperatorSelection(opID);
 
             if (!string.IsNullOrEmpty(operatorError))
@@ -271,16 +257,14 @@ namespace KiczanProductionInfoSystem
                 labelRecordStatus.Text = "Record Status: Record Successfully Updated!";
 
             }
-
             else
             {
 
                 labelRecordStatus.Text = "Record Status: Record Update Error!";
 
             }
-
         }
-
+        //Event handler for Clear button
         private void button2_Click(object sender, EventArgs e)
         {
             operatorComboBox.SelectedIndex = -1;
@@ -312,7 +296,7 @@ namespace KiczanProductionInfoSystem
                 checkedListBox1.SetItemChecked(i, false);
             }
         }
-        //Event handle for Back to Menu button.
+        //Event handler for Back to Menu button.
         private void button3_Click(object sender, EventArgs e)
         {
             this.Close();

--- a/KiczanProductionInfoSystem/UpdateRecord.cs
+++ b/KiczanProductionInfoSystem/UpdateRecord.cs
@@ -180,7 +180,7 @@ namespace KiczanProductionInfoSystem
             //Part number validation
             if (!newDV.validatePartNumber(partNumber))
             {
-                string message = "Part Number must not be empty and may only \n contain letters, numbers, or hyphen.";
+                string message = "Record not complete!\nPart Number must not be empty and may only\ncontain letters, numbers, or hyphen.";
                 labelPartNumberError.Text = message;
                 errorProviderPartNumber.SetError(textBoxPartNumber, message);
                 isValid = false;

--- a/KiczanProductionInfoSystem/UpdateRecord.cs
+++ b/KiczanProductionInfoSystem/UpdateRecord.cs
@@ -91,6 +91,22 @@ namespace KiczanProductionInfoSystem
                     checkedListBox1.SetItemChecked(checkedListBoxIndex, true);
                 }
             }
+            if (retrievedOperations.Contains("Lathe"))
+            {
+                int checkedListBoxIndex = checkedListBox1.FindStringExact("Lathe");
+                if (checkedListBoxIndex != -1)
+                {
+                    checkedListBox1.SetItemChecked(checkedListBoxIndex, true);
+                }
+            }
+            if (retrievedOperations.Contains("Mill"))
+            {
+                int checkedListBoxIndex = checkedListBox1.FindStringExact("Mill");
+                if (checkedListBoxIndex != -1)
+                {
+                    checkedListBox1.SetItemChecked(checkedListBoxIndex, true);
+                }
+            }
         }
         //eventhandler for checkboxlist
         private void checkedListBox1_SelectedIndexChanged(object sender, EventArgs e)

--- a/KiczanProductionInfoSystem/UpdateRecord.resx
+++ b/KiczanProductionInfoSystem/UpdateRecord.resx
@@ -1,0 +1,141 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <metadata name="errorProvider1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="errorProvider2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>246, 17</value>
+  </metadata>
+  <metadata name="errorProvider3.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>475, 17</value>
+  </metadata>
+  <metadata name="errorProviderPartNumber.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>704, 17</value>
+  </metadata>
+  <metadata name="errorProviderOperator.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1048, 17</value>
+  </metadata>
+  <metadata name="errorProviderCustomer.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>1359, 17</value>
+  </metadata>
+  <metadata name="errorProviderDateReceived.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 70</value>
+  </metadata>
+</root>


### PR DESCRIPTION
Fix: Added checkbox items for Lathe and Mill to CreateRecord and UpdateRecord forms.

Fix: Made error messages uniform, centered alignment in X and Y on corresponding input field.

Fix: Fixed tab order to flow down the form if the user uses tab to navigate the form for both CreateRecord and UpdateRecord.

Fix: New operations of Lathe and Mill were not checked in UpdateRecord after selecting record to update. Added logic to fix.